### PR TITLE
Add libgconf-2-4 requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Uses [bbc-a11y](https://github.com/bbc/bbc-a11y) and [Google Lighthouse](https:/
 
 ## Requirements
 - Node v6 or above
+- libgconf-2-4
 - Docker (if using the `ci` option)
 
 ## Installation of dependencies


### PR DESCRIPTION
libgconf needs to be installed, otherwise you get the following error message: `error while loading shared libraries: libgconf-2.so.4: cannot open shared object file: No such file or directory.`