### PR TITLE
Get iPlayer Web baseUrl from environment variable

### DIFF
--- a/config/iplayer-web/README.md
+++ b/config/iplayer-web/README.md
@@ -1,0 +1,10 @@
+# iPlayer Web Config
+
+## Usage
+
+As well as all the normal usage options, the iPlayer Web tests can be pointed at different `baseUrl`s using the `A11Y_IPLAYER_WEB_BASE_URL` environment variable. For example:
+
+
+```
+A11Y_CONFIG=iplayer-web/all A11Y_IPLAYER_WEB_BASE_URL=https://some.url npm run start:bbc-a11y
+```

--- a/config/iplayer-web/all.js
+++ b/config/iplayer-web/all.js
@@ -6,11 +6,11 @@ const homepage = require('./app-homepage-test');
 const lists = require('./app-lists-test');
 const myprogrammes = require('./app-myprogrammes-test');
 const playback = require('./app-playback-test');
-const { options } = require('./common');
+const { options, baseUrl } = require('./common');
 
 module.exports = {
   options,
-  baseUrl: 'https://www.bbc.co.uk',
+  baseUrl,
   paths: [
     ...features.paths,
     ...highlights.paths,

--- a/config/iplayer-web/app-features-test.js
+++ b/config/iplayer-web/app-features-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const { options } = require('./common');
+const { options, baseUrl } = require('./common');
 
 module.exports = {
   options,
-  baseUrl: 'https://frontdoor.iplayer.test.api.bbc.co.uk',
+  baseUrl,
   paths: [
     '/iplayer/features/accessibility',
     '/iplayer/features/downloads',

--- a/config/iplayer-web/app-highlights-test.js
+++ b/config/iplayer-web/app-highlights-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const { options } = require('./common');
+const { options, baseUrl } = require('./common');
 
 module.exports = {
   options,
-  baseUrl: 'https://frontdoor.iplayer.test.api.bbc.co.uk',
+  baseUrl,
   paths: [
     '/bbcone',
     '/bbctwo',

--- a/config/iplayer-web/app-homepage-test.js
+++ b/config/iplayer-web/app-homepage-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const { options } = require('./common');
+const { options, baseUrl } = require('./common');
 
 module.exports = {
   options,
-  baseUrl: 'https://frontdoor.iplayer.test.api.bbc.co.uk',
+  baseUrl,
   paths: [
     '/iplayer'
   ],

--- a/config/iplayer-web/app-lists-test.js
+++ b/config/iplayer-web/app-lists-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const { options } = require('./common');
+const { options, baseUrl } = require('./common');
 
 module.exports = {
   options,
-  baseUrl: 'https://frontdoor.iplayer.test.api.bbc.co.uk',
+  baseUrl,
   paths: [
     '/bbcone/a-z',
     '/iplayer/most-popular'

--- a/config/iplayer-web/app-myprogrammes-test.js
+++ b/config/iplayer-web/app-myprogrammes-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const { options } = require('./common');
+const { options, baseUrl } = require('./common');
 
 module.exports = {
   options,
-  baseUrl: 'https://frontdoor.iplayer.test.api.bbc.co.uk',
+  baseUrl,
   paths: [
     '/iplayer/recommendations'
   ],

--- a/config/iplayer-web/app-playback-test.js
+++ b/config/iplayer-web/app-playback-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { options: commonOptions } = require('./common');
+const { options: commonOptions, baseUrl } = require('./common');
 
 const commonSkips = commonOptions.skip;
 const playbackSpecificHides = ['carousel-outer-outer'];
@@ -17,7 +17,7 @@ const options = Object.assign({}, commonOptions,
 
 module.exports = {
   options,
-  baseUrl: 'https://frontdoor.iplayer.test.api.bbc.co.uk',
+  baseUrl,
   paths: [
     '/iplayer/episode/p04qh1gk/face-to-face-dame-edith-sitwell'
   ]

--- a/config/iplayer-web/common.js
+++ b/config/iplayer-web/common.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const baseUrl = process.env.A11Y_IPLAYER_WEB_BASE_URL || 'https://www.bbc.co.uk';
+
+module.exports = {
+  options: {
+    hide: ['orb', 'bbccookies-prompt', '/html/head/iframe', 'smphtml5iframebbcMediaPlayer', 'tvip-channels-stream-inner'],
+    skip: [
+      'Title attributes: Title attributes only on inputs',
+      'Tables: Use tables for data'
+    ]
+  },
+  baseUrl
+};

--- a/config/iplayer-web/common.json
+++ b/config/iplayer-web/common.json
@@ -1,9 +1,0 @@
-{
-  "options": {
-    "hide": ["orb", "bbccookies-prompt", "/html/head/iframe", "smphtml5iframebbcMediaPlayer", "tvip-channels-stream-inner"],
-    "skip": [
-      "Title attributes: Title attributes only on inputs",
-      "Tables: Use tables for data"
-    ]
-  }
-}

--- a/test/fixtures/lighthouseReport.json
+++ b/test/fixtures/lighthouseReport.json
@@ -2,8 +2,8 @@
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/62.0.3202.94 Safari/537.36",
   "lighthouseVersion": "2.6.0",
   "generatedTime": "2017-12-06T13:39:59.291Z",
-  "initialUrl": "https://frontdoor.iplayer.test.api.bbc.co.uk/iplayer/episode/p04qh1gk/face-to-face-dame-edith-sitwell",
-  "url": "https://frontdoor.iplayer.test.api.bbc.co.uk/iplayer/episode/p04qh1gk/face-to-face-dame-edith-sitwell",
+  "initialUrl": "https://www.bbc.co.uk/iplayer/episode/p04qh1gk/face-to-face-dame-edith-sitwell",
+  "url": "https://www.bbc.co.uk/iplayer/episode/p04qh1gk/face-to-face-dame-edith-sitwell",
   "audits": {
     "aria-roles": {
       "score": true,


### PR DESCRIPTION
Removes hardcoded URLs from iPlayer Web config and adds the ability to set the baseUrl with the `A11Y_IPLAYER_WEB_BASE_URL` environment variable