### PR TITLE
iPlayer config updates

### DIFF
--- a/config/iplayer-web/all.js
+++ b/config/iplayer-web/all.js
@@ -6,7 +6,9 @@ const homepage = require('./app-homepage-test');
 const lists = require('./app-lists-test');
 const myprogrammes = require('./app-myprogrammes-test');
 const playback = require('./app-playback-test');
-const { options, baseUrl } = require('./common');
+const { options } = require('./common');
+
+const baseUrl = process.env.A11Y_IPLAYER_WEB_BASE_URL || 'https://www.bbc.co.uk';
 
 module.exports = {
   options,
@@ -18,12 +20,6 @@ module.exports = {
     ...lists.paths,
     ...myprogrammes.paths,
     ...playback.paths,
-    '/iplayer/categories/arts/highlights',
-    '/iplayer/categories/arts/all?sort=atoz',
-    '/iplayer/categories/arts/all?sort=dateavailable',
-    '/iplayer/categories/drama-sci-fi-and-fantasy/highlights',
-    '/iplayer/categories/drama-sci-fi-and-fantasy/all?sort=atoz',
-    '/iplayer/categories/drama-sci-fi-and-fantasy/all?sort=dateavailable',
     '/iplayer/a-z/a',
     '/iplayer/guide',
     '/iplayer/watching',

--- a/config/iplayer-web/app-lists-test.js
+++ b/config/iplayer-web/app-lists-test.js
@@ -7,6 +7,14 @@ module.exports = {
   baseUrl,
   paths: [
     '/bbcone/a-z',
-    '/iplayer/most-popular'
+    '/iplayer/most-popular',
+    '/iplayer/categories/arts/featured',
+    '/iplayer/categories/arts/a-z',
+    '/iplayer/categories/arts/most-recent',
+    '/iplayer/categories/drama-sci-fi-and-fantasy/featured',
+    '/iplayer/categories/drama-sci-fi-and-fantasy/a-z',
+    '/iplayer/categories/drama-sci-fi-and-fantasy/most-recent',
+    '/iplayer/search?q=east',
+    '/iplayer/episodes/b006m86d'
   ]
 };

--- a/config/iplayer-web/common.js
+++ b/config/iplayer-web/common.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const baseUrl = process.env.A11Y_IPLAYER_WEB_BASE_URL || 'https://www.bbc.co.uk';
+const baseUrl = process.env.A11Y_IPLAYER_WEB_BASE_URL || 'https://test.bbc.co.uk';
 
 // Skipped tests are those for which we have tickets prioritised in the backlog to fix
 


### PR DESCRIPTION
- Update to use test.bbc.co.uk by default for test configs
- Add new paths to app-lists-test config