### PR TITLE
Separate out signed in config for iPlayer homepage and add lists themed config

### DIFF
--- a/config/iplayer-web/app-homepage-test-signed-in.js
+++ b/config/iplayer-web/app-homepage-test-signed-in.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { options, baseUrl } = require('./common');
+
+module.exports = {
+  options,
+  baseUrl,
+  signedInPaths: [
+    '/iplayer'
+  ]
+};

--- a/config/iplayer-web/app-homepage-test.js
+++ b/config/iplayer-web/app-homepage-test.js
@@ -1,14 +1,10 @@
 'use strict';
 
-const { options, baseUrl } = require('./common');
+const homepageSignedIn = require('./app-homepage-test-signed-in');
 
 module.exports = {
-  options,
-  baseUrl,
+  ...homepageSignedIn,
   paths: [
-    '/iplayer'
-  ],
-  signedInPaths: [
     '/iplayer'
   ]
 };

--- a/config/iplayer-web/app-lists-test-themed.js
+++ b/config/iplayer-web/app-lists-test-themed.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { options, baseUrl } = require('./common');
+
+module.exports = {
+  options,
+  baseUrl,
+  signedInPaths: [
+    '/iplayer/group/u13-entertainment',
+    '/iplayer/episodes/b006m86d'
+  ]
+};


### PR DESCRIPTION
Enables testing of theming for the young audience.