### PR TITLE
Unbreak tests for cases with no user / pass

### DIFF
--- a/lib/bbcA11y.js
+++ b/lib/bbcA11y.js
@@ -24,12 +24,14 @@ function build() {
     logger.error(`No paths listed in the config for ${configName}`);
     process.exit(1);
   }
+
   const signedOutOutput = pathsToOutput(baseUrl, paths, config.options);
   const signedInOutput = pathsToOutput(baseUrl, signedInPaths, config.options, true);
   const a11yOutput = `
     ${signedOutOutput}
     ${signedInOutput}
   `;
+
   fs.writeFileSync(configFilePath, a11yOutput);
 
   logger.log(`Tests will run against: ${domain} ${paths.join(' ')}`);

--- a/lib/bbcA11y.js
+++ b/lib/bbcA11y.js
@@ -24,14 +24,12 @@ function build() {
     logger.error(`No paths listed in the config for ${configName}`);
     process.exit(1);
   }
-
   const signedOutOutput = pathsToOutput(baseUrl, paths, config.options);
   const signedInOutput = pathsToOutput(baseUrl, signedInPaths, config.options, true);
   const a11yOutput = `
     ${signedOutOutput}
     ${signedInOutput}
   `;
-
   fs.writeFileSync(configFilePath, a11yOutput);
 
   logger.log(`Tests will run against: ${domain} ${paths.join(' ')}`);

--- a/test/lib/bbcA11y.js
+++ b/test/lib/bbcA11y.js
@@ -182,12 +182,12 @@ describe('bbcA11y', () => {
 
     });
 
-    describe.only('Paths and signed in paths and baseUrl but no options and no username and password', () => {
+    describe('Paths and signed in paths and baseUrl but no options and no username and password', () => {
       beforeEach(() => {
         process.env.A11Y_CONFIG = 'test/paths-with-signed-in-and-baseurl';
+        delete process.env.A11Y_USERNAME;
+        delete process.env.A11Y_PASSWORD;
       });
-
-      // BORK
 
       it('outputs the basic config for the paths but not signed in paths', () => {
         const expectedOutput = `
@@ -195,9 +195,7 @@ describe('bbcA11y', () => {
           page( "http://base.url/path/2", { } )
         `;
         const matcher = getMinifiedMatcher(expectedOutput);
-
         bbcA11y.build();
-
         sandbox.assert.calledWith(
           fs.writeFileSync,
           path.resolve(`${__dirname}/../../a11y.js`),
@@ -205,16 +203,12 @@ describe('bbcA11y', () => {
         );
       });
 
-      // BORK
-
       it('logs what domain and paths it will run against', () => {
         bbcA11y.build();
 
         sandbox.assert.calledWith(colourfulLog.log, 'Tests will run against: base.url /path/1 /path/2');
         sandbox.assert.neverCalledWith(colourfulLog.log, sandbox.match('Tests will run signed in'));
       });
-
-      // BORK
 
       it('logs a warning', () => {
         bbcA11y.build();

--- a/test/lib/bbcA11y.js
+++ b/test/lib/bbcA11y.js
@@ -195,7 +195,9 @@ describe('bbcA11y', () => {
           page( "http://base.url/path/2", { } )
         `;
         const matcher = getMinifiedMatcher(expectedOutput);
+
         bbcA11y.build();
+
         sandbox.assert.calledWith(
           fs.writeFileSync,
           path.resolve(`${__dirname}/../../a11y.js`),

--- a/test/lib/bbcA11y.js
+++ b/test/lib/bbcA11y.js
@@ -182,10 +182,12 @@ describe('bbcA11y', () => {
 
     });
 
-    describe('Paths and signed in paths and baseUrl but no options and no username and password', () => {
+    describe.only('Paths and signed in paths and baseUrl but no options and no username and password', () => {
       beforeEach(() => {
         process.env.A11Y_CONFIG = 'test/paths-with-signed-in-and-baseurl';
       });
+
+      // BORK
 
       it('outputs the basic config for the paths but not signed in paths', () => {
         const expectedOutput = `
@@ -203,12 +205,16 @@ describe('bbcA11y', () => {
         );
       });
 
+      // BORK
+
       it('logs what domain and paths it will run against', () => {
         bbcA11y.build();
 
         sandbox.assert.calledWith(colourfulLog.log, 'Tests will run against: base.url /path/1 /path/2');
         sandbox.assert.neverCalledWith(colourfulLog.log, sandbox.match('Tests will run signed in'));
       });
+
+      // BORK
 
       it('logs a warning', () => {
         bbcA11y.build();

--- a/test/lib/lighthouse.js
+++ b/test/lib/lighthouse.js
@@ -342,10 +342,12 @@ describe('lighthouse', () => {
       });
     });
 
-    describe('Paths and signed in paths and baseUrl but no username and password', () => {
+    describe.only('Paths and signed in paths and baseUrl but no username and password', () => {
       beforeEach(() => {
         process.env.A11Y_CONFIG = 'test/paths-with-signed-in-and-baseurl';
       });
+
+      // BORK
 
       it('logs what domain and paths it will run against', () => {
         return lighthouseRunner.run().then(() => {
@@ -354,6 +356,8 @@ describe('lighthouse', () => {
         });
       });
 
+      // BORK
+
       it('launches lighthouse for the signed out paths only', () => {
         return lighthouseRunner.run().then(() => {
           sandbox.assert.calledTwice(external.lighthouse);
@@ -361,6 +365,8 @@ describe('lighthouse', () => {
           sandbox.assert.calledWith(external.lighthouse, 'http://base.url/path/2');
         });
       });
+
+      // BORK
 
       it('logs a warning about skipping signed in paths', () => {
         return lighthouseRunner.run().then(() => {

--- a/test/lib/lighthouse.js
+++ b/test/lib/lighthouse.js
@@ -342,12 +342,12 @@ describe('lighthouse', () => {
       });
     });
 
-    describe.only('Paths and signed in paths and baseUrl but no username and password', () => {
+    describe('Paths and signed in paths and baseUrl but no username and password', () => {
       beforeEach(() => {
         process.env.A11Y_CONFIG = 'test/paths-with-signed-in-and-baseurl';
+        delete process.env.A11Y_USERNAME;
+        delete process.env.A11Y_PASSWORD;
       });
-
-      // BORK
 
       it('logs what domain and paths it will run against', () => {
         return lighthouseRunner.run().then(() => {
@@ -356,8 +356,6 @@ describe('lighthouse', () => {
         });
       });
 
-      // BORK
-
       it('launches lighthouse for the signed out paths only', () => {
         return lighthouseRunner.run().then(() => {
           sandbox.assert.calledTwice(external.lighthouse);
@@ -365,8 +363,6 @@ describe('lighthouse', () => {
           sandbox.assert.calledWith(external.lighthouse, 'http://base.url/path/2');
         });
       });
-
-      // BORK
 
       it('logs a warning about skipping signed in paths', () => {
         return lighthouseRunner.run().then(() => {


### PR DESCRIPTION
Our tests clone process.env before each test and restore it after each.

Tests for the case where no user & password were failing when a user & password existed in `process.env` (i.e. if your env is set up to run the a11y tools.)

Added `delete`s for `A11Y_USERNAME` and `A11Y_PASSWORD` in the relevant beforeEach blocks.