### PR TITLE
Bump Lighthouse version and add flag for verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ To run Google Lighthouse in headless mode and generate human-readable output to 
 A11Y_CONFIG=iplayer-web/all npm run start:lighthouse:headless
 ```
 
+### Run Google Lighthouse with verbose logging enabled
+
+To run Google Lighthouse in headless mode and enable verbose logging to console for Lighthouse:
+
+```
+A11Y_CONFIG=iplayer-web/all A11Y_LOGGING_LEVEL=verbose npm run start:lighthouse:headless
+```
+
 ## Running on Jenkins
 
 If you'd like to run this on your Jenkins server, ensure your Jenkins meets the requirements above and has a [JUnit plugin](https://plugins.jenkins.io/junit) installed and then:

--- a/lib/bbcA11y.js
+++ b/lib/bbcA11y.js
@@ -44,6 +44,7 @@ function clean() {
   try {
     fs.unlinkSync(configFilePath);
   } catch (e) {
+    logger.log('Error cleaning but this should be OK', e);
     // Cannot delete file (probably because it does not exist).
   }
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -41,9 +41,20 @@ function getSignedInPaths(config) {
   return paths;
 }
 
+function getLoggingLevel() {
+  const { A11Y_LOGGING_LEVEL: loggingLevel } = process.env;
+
+  if (loggingLevel === 'verbose') {
+    return loggingLevel;
+  }
+
+  return 'silent';
+}
+
 module.exports = {
   getConfigName,
   getConfig,
   getSignedInPaths,
-  getSignInCredentials
+  getSignInCredentials,
+  getLoggingLevel
 };

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -11,7 +11,8 @@ const {
   getConfigName,
   getConfig,
   getSignedInPaths,
-  getSignInCredentials
+  getSignInCredentials,
+  getLoggingLevel
 } = require('./common');
 
 const LIGHTHOUSE_OPTS = {
@@ -27,7 +28,7 @@ const LIGHTHOUSE_OPTS = {
     }
   },
   flags: {
-    logLevel: 'verbose',
+    logLevel: getLoggingLevel(),
     output: 'json'
   }
 };

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -27,7 +27,7 @@ const LIGHTHOUSE_OPTS = {
     }
   },
   flags: {
-    logLevel: 'silent',
+    logLevel: 'verbose',
     output: 'json'
   }
 };
@@ -122,9 +122,12 @@ function launchChromeAndRunLighthouse(url, shouldSignIn) {
           return external.lighthouse(url, lighthouseFlags, lightHouseConfig);
         })
         .then((results) => chrome.kill().then(() => results))
-        .catch(() => {
+        .catch((err) => {
           chrome.kill();
+          logger.error('Could not run lighthouse', err)
         });
+    }).catch((err) => {
+      logger.error('Could not launch Chrome', err);
     });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -532,9 +532,9 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -658,9 +658,9 @@
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
     "axe-core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.4.1.tgz",
-      "integrity": "sha512-5Pmy37rmZxRqEfQxCs6HMbqKTZx7FI0hKb2vbMgjhHfyobu4jFUhXkL2miB/eujn5kNdgKepWSruq+MAS77yGA=="
+      "version": "3.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.0.0-beta.2.tgz",
+      "integrity": "sha512-JyMXnHDuzr6hei+mINWsR/iEyPBFSjpgF4/lUijO7QDGVKtTmdpDxc2+7X/xW+rPIwhcd72euJ2UunbRXF+1Eg=="
     },
     "babar": {
       "version": "0.0.3",
@@ -668,13 +668,6 @@
       "integrity": "sha1-LzlNSlkY9+GunlQI6alvP5Ne4eI=",
       "requires": {
         "colors": "~0.6.2"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
-        }
       }
     },
     "backo2": {
@@ -918,9 +911,9 @@
       }
     },
     "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -994,6 +987,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "chokidar": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
@@ -1060,6 +1058,11 @@
           "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
         }
       }
+    },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
     },
     "classifier": {
       "version": "0.1.0",
@@ -1216,6 +1219,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1260,9 +1268,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
         "dot-prop": "^4.1.0",
         "graceful-fs": "^4.1.2",
@@ -1367,6 +1375,11 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -2094,6 +2107,7 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0"
           }
         },
@@ -2386,9 +2400,9 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "external-editor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "^0.4.0",
         "iconv-lite": "^0.4.17",
@@ -2988,6 +3002,14 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
     "has-binary2": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
@@ -3259,9 +3281,12 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "ignore": {
       "version": "4.0.6",
@@ -3357,11 +3382,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3412,8 +3432,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -3428,6 +3447,14 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
       "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
+    },
+    "is-ci": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "requires": {
+        "ci-info": "^1.5.0"
+      }
     },
     "is-date-object": {
       "version": "1.0.2",
@@ -3503,17 +3530,12 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
         "path-is-inside": "^1.0.1"
       }
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -3530,9 +3552,9 @@
       }
     },
     "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -4046,27 +4068,30 @@
       }
     },
     "lighthouse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-2.7.0.tgz",
-      "integrity": "sha512-Ng+90jCos0BS9i9PZbSiU08FIkd6OdJfxUmDek0KuLwubF4D8tew+Zn1zhDeHQaQa5b+oBvLleq/Ty23kdflBw==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-2.9.4.tgz",
+      "integrity": "sha512-z+6JLc1gWXfiSCZYvhdLRKvwjC+fUBXTi+3zobRTiNwJxCJbZdePe93boKAfUHsLyVWEcihLplRXW7IV6wV2Fw==",
       "requires": {
-        "axe-core": "2.4.1",
+        "axe-core": "3.0.0-beta.2",
         "chrome-devtools-frontend": "1.0.422034",
-        "chrome-launcher": "0.8.1",
+        "chrome-launcher": "^0.10.2",
         "configstore": "^3.1.1",
         "devtools-timeline-model": "1.1.6",
+        "esprima": "^4.0.0",
         "http-link-header": "^0.8.0",
         "inquirer": "^3.3.0",
         "jpeg-js": "0.1.2",
-        "js-library-detector": "^4.0.0",
-        "json-stringify-safe": "5.0.1",
+        "js-library-detector": "^4.3.1",
         "lighthouse-logger": "^1.0.0",
-        "metaviewport-parser": "0.1.0",
+        "lodash.isequal": "^4.5.0",
+        "metaviewport-parser": "0.2.0",
         "mkdirp": "0.5.1",
         "opn": "4.0.2",
         "parse-cache-control": "1.0.1",
+        "patch-package": "^5.1.1",
         "raven": "^2.2.1",
         "rimraf": "^2.6.1",
+        "robots-parser": "^1.0.2",
         "semver": "^5.3.0",
         "speedline": "1.3.0",
         "update-notifier": "^2.1.0",
@@ -4076,20 +4101,12 @@
         "yargs-parser": "7.0.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "6.0.66",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.66.tgz",
-          "integrity": "sha1-VoC3SmE10z1MAER+fD3GkaRgFiU="
-        },
         "chrome-launcher": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.8.1.tgz",
-          "integrity": "sha512-YhLMJ5acDodfRfIL6Vzv1NQ3ygAHqW78BJJryRxlcUdcvkfp3/R1V+qEBDi2S0k07/bZIubqfRIsKsg25GqQBQ==",
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.10.7.tgz",
+          "integrity": "sha512-IoQLp64s2n8OQuvKZwt77CscVj3UlV2Dj7yZtd1EBMld9mSdGcsGy9fN5hd/r4vJuWZR09it78n1+A17gB+AIQ==",
           "requires": {
-            "@types/core-js": "^0.9.41",
-            "@types/mkdirp": "^0.3.29",
-            "@types/node": "6.0.66",
-            "@types/rimraf": "^0.0.28",
+            "@types/node": "*",
             "is-wsl": "^1.1.0",
             "lighthouse-logger": "^1.0.0",
             "mkdirp": "0.5.1",
@@ -4105,11 +4122,6 @@
             "strip-ansi": "^3.0.1",
             "wrap-ansi": "^2.0.0"
           }
-        },
-        "is-wsl": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
         },
         "minimist": {
           "version": "0.0.8",
@@ -4191,6 +4203,11 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -4280,23 +4297,18 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
-    },
-    "lsmod": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz",
-      "integrity": "sha1-mgD3bco26yP6BTUK/htYXUKZ5ks="
     },
     "lzutf8": {
       "version": "0.5.5",
@@ -4304,9 +4316,9 @@
       "integrity": "sha512-x4AdRtP0ETRe0BW8V+TfW+8rOF5t3vWU/Z52twUqDRf0OiEuXiLvXNN6Zm8biFCTI9ffXBZb++THAjfkJ559Nw=="
     },
     "make-dir": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
         "pify": "^3.0.0"
       },
@@ -4322,6 +4334,16 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -4351,9 +4373,9 @@
       "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
     },
     "metaviewport-parser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.1.0.tgz",
-      "integrity": "sha1-l/pn6ku/ZA9P1ZAQ+I8QzqfVrMw="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.2.0.tgz",
+      "integrity": "sha1-U1w84cz2IjpQJf3cahw2UF9+fbE="
     },
     "mime-db": {
       "version": "1.44.0",
@@ -4369,9 +4391,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "min-document": {
       "version": "2.19.0",
@@ -5202,6 +5224,71 @@
         "upper-case-first": "^1.1.0"
       }
     },
+    "patch-package": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-5.1.2.tgz",
+      "integrity": "sha512-6NA7/hcAG/eZ6TcugOIkmRMA9wg/CVm+gyJpWJwc7Z8E0dkMeQwnVw5oDvhG+bEHBhsQLn+rF7PAx7p2QWnfNA==",
+      "requires": {
+        "chalk": "^1.1.3",
+        "cross-spawn": "^5.1.0",
+        "fs-extra": "^4.0.1",
+        "minimist": "^1.2.0",
+        "rimraf": "^2.6.1",
+        "slash": "^1.0.0",
+        "tmp": "^0.0.31",
+        "update-notifier": "^2.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "tmp": {
+          "version": "0.0.31",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+          "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        }
+      }
+    },
     "path-case": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
@@ -5429,21 +5516,21 @@
       "integrity": "sha1-pG5DdTUr7amg17DRntbTIezR2C0="
     },
     "raven": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.3.0.tgz",
-      "integrity": "sha1-lvFTRr2qQzs7bUcTCARQYVWDPWk=",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
+      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
       "requires": {
         "cookie": "0.3.1",
-        "lsmod": "1.0.0",
-        "stack-trace": "0.0.9",
+        "md5": "^2.2.1",
+        "stack-trace": "0.0.10",
         "timed-out": "4.0.1",
-        "uuid": "3.0.0"
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "uuid": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
-          "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -5692,13 +5779,15 @@
         "glob": "^7.0.5"
       }
     },
+    "robots-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-1.0.2.tgz",
+      "integrity": "sha512-c979P2TTe5Ezjg+VV5XWC59bab1w1Xyb8KLnJ5SKuwN7YH+ys8Y5KCZ2OP2J7zXVE7Yq0eYWlrqUM/urIbx9sg=="
+    },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -5816,6 +5905,11 @@
         "text-encoding": "0.6.4",
         "type-detect": "^4.0.0"
       }
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -6115,9 +6209,9 @@
       }
     },
     "stack-trace": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "statuses": {
       "version": "1.5.0",
@@ -6438,13 +6532,6 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
         "punycode": "^2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-        }
       }
     },
     "trim-newlines": {
@@ -6594,20 +6681,26 @@
         "crypto-random-string": "^1.0.0"
       }
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
     "unzip-response": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
       "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
     },
     "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "requires": {
         "boxen": "^1.2.1",
         "chalk": "^2.0.1",
         "configstore": "^3.0.0",
         "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
         "is-installed-globally": "^0.1.0",
         "is-npm": "^1.0.0",
         "latest-version": "^3.0.0",
@@ -6692,19 +6785,19 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "requires": {
         "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.0",
-        "webidl-conversions": "^4.0.1"
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -6724,9 +6817,9 @@
       }
     },
     "widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "requires": {
         "string-width": "^2.1.1"
       },
@@ -6801,9 +6894,9 @@
       }
     },
     "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chrome-launcher": "^0.8.1",
     "chrome-remote-interface": "^0.25.4",
     "junit-report-builder": "^1.3.2",
-    "lighthouse": "^2.7.0",
+    "lighthouse": "^2.9.4",
     "xunit-viewer": "^6.3.9",
     "yargs": "^14.0.0"
   },

--- a/test/lib/lighthouse.js
+++ b/test/lib/lighthouse.js
@@ -21,7 +21,7 @@ function getMinifiedMatcher(code) {
 }
 
 const EXPECTED_LIGHTHOUSE_FLAGS = {
-  logLevel: 'verbose',
+  logLevel: 'silent',
   output: 'json',
   port: 1234
 };

--- a/test/lib/lighthouse.js
+++ b/test/lib/lighthouse.js
@@ -21,7 +21,7 @@ function getMinifiedMatcher(code) {
 }
 
 const EXPECTED_LIGHTHOUSE_FLAGS = {
-  logLevel: 'silent',
+  logLevel: 'verbose',
   output: 'json',
   port: 1234
 };


### PR DESCRIPTION
## Background

Getting intermittent failure on Jenkins BlueOcean when running a11y-tests-web:
```TypeError: Cannot destructure property 'audits' of 'results' as it is undefined```

## Resolution

- Bump Google Lighthouse dependency to ^2.9.4 from ^2.7.0
- Change logging output level from silent to verbose
- Add additional logging in case of future errors