### PR TITLE
fix: Remove sub categories from iplayer-web lists suite

### DIFF
--- a/config/iplayer-web/app-lists-test.js
+++ b/config/iplayer-web/app-lists-test.js
@@ -11,9 +11,6 @@ module.exports = {
     '/iplayer/categories/arts/featured',
     '/iplayer/categories/arts/a-z',
     '/iplayer/categories/arts/most-recent',
-    '/iplayer/categories/drama-sci-fi-and-fantasy/featured',
-    '/iplayer/categories/drama-sci-fi-and-fantasy/a-z',
-    '/iplayer/categories/drama-sci-fi-and-fantasy/most-recent',
     '/iplayer/search?q=east',
     '/iplayer/episodes/b006m86d'
   ]


### PR DESCRIPTION
## Changes
- Remove subcategories from iplayer-web lists suite as the new featured page will 404 for subcategories