### PR TITLE
Attempt to fix flakey Lighthouse error and improve logging

### DIFF
--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -170,35 +170,41 @@ function completeSetupSteps(chrome, url, shouldSignIn) {
   return Promise.resolve();
 }
 
-function signInToBBCID(chrome, url) {
-  return external.CDP({ port: chrome.port })
-    .then((chromeProtocols) => loadSignInPage(url, chromeProtocols))
-    .then(completeSignInProcess);
+async function signInToBBCID(chrome, url) {
+  const chromeProtocols = await external.CDP({ port: chrome.port });
+  await loadSignInPage(url, chromeProtocols);
+  await completeSignInProcess(chromeProtocols);
 }
 
-function loadSignInPage(url, { Page, Runtime }) {
+async function loadSignInPage(url, { Page }) {
   const encodedUrl = encodeURIComponent(url);
   const signInUrl = `https://account.bbc.com/signin?ptrt=${encodedUrl}`;
 
-  return new Promise((resolve) => {
-    Page.enable()
-      .then(() => Page.navigate({ url: signInUrl }))
-      .then(() => {
-        Page.loadEventFired(() => resolve({ Page, Runtime }));
-      });
+  return new Promise(async (resolve) => {
+    await Page.enable();
+    await Page.navigate({ url: signInUrl });
+    console.log('load sign in page - page navigated to');
+    await Page.loadEventFired(() => {
+      console.log('load sign in page - load event fired');
+      return resolve();
+    });
   });
 }
 
 function completeSignInProcess({ Page, Runtime }) {
-  return new Promise((resolve) => {
+  return new Promise(async (resolve) => {
     const { username, password } = getSignInCredentials();
     const loginScript = `
       document.getElementById('user-identifier-input').value = '${username}';
       document.getElementById('password-input').value = '${password}';
       document.getElementById('submit-button').click();
     `;
-    Page.loadEventFired(resolve);
-    Runtime.evaluate({ expression: loginScript });
+    await Page.loadEventFired(() => {
+      console.log('sign in process - load event fired');
+      Runtime.evaluate({ expression: loginScript });
+      console.log('sign in process - login script invoked');
+      resolve();
+    });
   });
 }
 

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -171,15 +171,11 @@ function completeSetupSteps(chrome, url, shouldSignIn) {
 }
 
 async function signInToBBCID(chrome, url) {
-  let chromeProtocols;
-  try {
-    const chromeProtocols = await external.CDP({ port: chrome.port });
-  } catch (err) {
-    console.error('Could not obtain chrome protocols', chromeProtocols, err);
-    return;
-  }
-  await loadSignInPage(url, chromeProtocols);
-  await completeSignInProcess(chromeProtocols);
+  return external.CDP({ port: chrome.port })
+    .then(async (chromeProtocols) => {
+      await loadSignInPage(url, chromeProtocols);
+      await completeSignInProcess(chromeProtocols);
+    }).catch((err) => console.error('Could not obtain chrome protocols', err));
 }
 
 async function loadSignInPage(url, { Page }) {

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -107,29 +107,44 @@ function runTestsForUrl({ url, shouldSignIn, hide, isPretty }) {
       });
     })
     .catch((err) => {
-      logger.error(err);
+      logger.error('An error occurding while launching Chrome and running Lighthouse', err);
       process.exit(1);
     });
 }
 
-function launchChromeAndRunLighthouse(url, shouldSignIn) {
+async function launchChromeAndRunLighthouse(url, shouldSignIn) {
   const { flags: lighthouseFlags, config: lightHouseConfig } = LIGHTHOUSE_OPTS;
   const chromeOpts = getChromeOpts();
-  return chromeLauncher.launch(chromeOpts)
-    .then((chrome) => {
-      return completeSetupSteps(chrome, url, shouldSignIn)
-        .then(() => {
-          lighthouseFlags.port = chrome.port;
-          return external.lighthouse(url, lighthouseFlags, lightHouseConfig);
-        })
-        .then((results) => chrome.kill().then(() => results))
-        .catch((err) => {
-          chrome.kill();
-          logger.error('Could not run lighthouse', err);
-        });
-    }).catch((err) => {
-      logger.error('Could not launch Chrome', err);
-    });
+
+  let chrome;
+  let results;
+
+  try {
+    chrome = await chromeLauncher.launch(chromeOpts);
+  } catch (err) {
+    return logger.error('Failed to launch Chrome', err);
+  }
+
+  try {
+    await completeSetupSteps(chrome, url, shouldSignIn);
+  } catch (err) {
+    return logger.error('Failed to complete setup steps', { chrome, url, shouldSignIn }, err);
+  }
+
+  try {
+    lighthouseFlags.port = chrome.port;
+    results = await external.lighthouse(url, lighthouseFlags, lightHouseConfig);
+  } catch (err) {
+    logger.error('Failed to launch Lighthouse', { url, lighthouseFlags, lightHouseConfig }, err);
+  }
+
+  try {
+    await chrome.kill();
+  } catch (err) {
+    return logger.error('Failed to quit Chrome', err);
+  }
+
+  return results;
 }
 
 function getChromeOpts() {

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -171,7 +171,13 @@ function completeSetupSteps(chrome, url, shouldSignIn) {
 }
 
 async function signInToBBCID(chrome, url) {
-  const chromeProtocols = await external.CDP({ port: chrome.port });
+  let chromeProtocols;
+  try {
+    const chromeProtocols = await external.CDP({ port: chrome.port });
+  } catch (err) {
+    console.error('Could not obtain chrome protocols', chromeProtocols, err);
+    return;
+  }
   await loadSignInPage(url, chromeProtocols);
   await completeSignInProcess(chromeProtocols);
 }

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -106,7 +106,7 @@ async function runTestsForUrl({ url, shouldSignIn, hide, isPretty }) {
       }
     });
   } catch (err) {
-    logger.error(`An error occureding while launching Chrome and running Lighthouse.\nError: ${err}`);
+    logger.error(`An error occurred while launching Chrome and running Lighthouse.\nError: ${err}`);
     process.exit(1);
   }
 }

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -107,7 +107,8 @@ function runTestsForUrl({ url, shouldSignIn, hide, isPretty }) {
       });
     })
     .catch((err) => {
-      logger.error('An error occurding while launching Chrome and running Lighthouse', err);
+      logger.error('An error occurding while launching Chrome and running Lighthouse');
+      console.error(err);
       process.exit(1);
     });
 }
@@ -122,26 +123,26 @@ async function launchChromeAndRunLighthouse(url, shouldSignIn) {
   try {
     chrome = await chromeLauncher.launch(chromeOpts);
   } catch (err) {
-    return logger.error('Failed to launch Chrome', err);
+    return console.error('Failed to launch Chrome', err);
   }
 
   try {
     await completeSetupSteps(chrome, url, shouldSignIn);
   } catch (err) {
-    return logger.error('Failed to complete setup steps', { chrome, url, shouldSignIn }, err);
+    return console.error('Failed to complete setup steps', { chrome, url, shouldSignIn }, err);
   }
 
   try {
     lighthouseFlags.port = chrome.port;
     results = await external.lighthouse(url, lighthouseFlags, lightHouseConfig);
   } catch (err) {
-    logger.error('Failed to launch Lighthouse', { url, lighthouseFlags, lightHouseConfig }, err);
+    console.error('Failed to launch Lighthouse', { url, lighthouseFlags, lightHouseConfig }, err);
   }
 
   try {
     await chrome.kill();
   } catch (err) {
-    return logger.error('Failed to quit Chrome', err);
+    return console.error('Failed to quit Chrome', err);
   }
 
   return results;

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -170,43 +170,65 @@ function completeSetupSteps(chrome, url, shouldSignIn) {
 }
 
 async function signInToBBCID(chrome, url) {
-  return external.CDP({ port: chrome.port })
-    .then(async (chromeProtocols) => {
-      await loadSignInPage(url, chromeProtocols);
-      await completeSignInProcess(chromeProtocols);
-    }).catch((err) => logger.error(`Could not obtain chrome protocols.\nError: ${err}`));
+  let chromeProtocols;
+
+  try {
+    chromeProtocols = await external.CDP({ port: chrome.port });
+  } catch (err) {
+    return logger.error(`Could not obtain chrome protocols.\nError: ${err}`);
+  }
+
+  try {
+    await loadSignInPage(url, chromeProtocols);
+  } catch (err) {
+    return logger.error(`Could not load sign in page.\nError: ${err}`);
+  }
+
+  try {
+    await completeSignInProcess(chromeProtocols);
+  } catch (err) {
+    return logger.error(`Could not complete sign in process.\nError: ${err}`);
+  }
 }
 
 async function loadSignInPage(url, { Page }) {
   const encodedUrl = encodeURIComponent(url);
   const signInUrl = `https://account.bbc.com/signin?ptrt=${encodedUrl}`;
 
-  return new Promise(async (resolve) => {
-    await Page.enable();
-    await Page.navigate({ url: signInUrl });
-    logger.log('load sign in page - page navigated to');
-    await Page.loadEventFired(() => {
-      logger.log('load sign in page - load event fired');
-      return resolve();
-    });
+  return new Promise(async (resolve, reject) => {
+    try {
+      await Page.enable();
+      await Page.navigate({ url: signInUrl });
+      logger.log('load sign in page - page navigated to');
+      await Page.loadEventFired(() => {
+        logger.log('load sign in page - load event fired');
+        return resolve();
+      });
+    } catch (err) {
+      return reject(err);
+    }
   });
 }
 
 function completeSignInProcess({ Page, Runtime }) {
-  return new Promise(async (resolve) => {
-    logger.log('sign in process - about to try to sign in');
-    const { username, password } = getSignInCredentials();
-    const loginScript = `
-      document.getElementById('user-identifier-input').value = '${username}';
-      document.getElementById('password-input').value = '${password}';
-      document.getElementById('submit-button').click();
-    `;
-    Runtime.evaluate({ expression: loginScript });
-    logger.log('sign in process - login script invoked');
-    await Page.loadEventFired(() => {
-      logger.log('sign in process - load event fired');
-      return resolve();
-    });
+  return new Promise(async (resolve, reject) => {
+    try {
+      logger.log('sign in process - about to try to sign in');
+      const { username, password } = getSignInCredentials();
+      const loginScript = `
+        document.getElementById('user-identifier-input').value = '${username}';
+        document.getElementById('password-input').value = '${password}';
+        document.getElementById('submit-button').click();
+      `;
+      Runtime.evaluate({ expression: loginScript });
+      logger.log('sign in process - login script invoked');
+      await Page.loadEventFired(() => {
+        logger.log('sign in process - load event fired');
+        return resolve();
+      });
+    } catch (err) {
+      return reject(err);
+    }
   });
 }
 

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -107,8 +107,7 @@ function runTestsForUrl({ url, shouldSignIn, hide, isPretty }) {
       });
     })
     .catch((err) => {
-      logger.error('An error occurding while launching Chrome and running Lighthouse');
-      console.error(err);
+      logger.error(`An error occurding while launching Chrome and running Lighthouse.\nError: ${err}`);
       process.exit(1);
     });
 }
@@ -123,26 +122,26 @@ async function launchChromeAndRunLighthouse(url, shouldSignIn) {
   try {
     chrome = await chromeLauncher.launch(chromeOpts);
   } catch (err) {
-    return console.error('Failed to launch Chrome', err);
+    return logger.error(`Failed to launch Chrome.\nError: ${err}`);
   }
 
   try {
     await completeSetupSteps(chrome, url, shouldSignIn);
   } catch (err) {
-    return console.error('Failed to complete setup steps', { chrome, url, shouldSignIn }, err);
+    return logger.error(`Failed to complete setup steps.\nError: ${err}\nDebug: ${{ chrome, url, shouldSignIn }}`);
   }
 
   try {
     lighthouseFlags.port = chrome.port;
     results = await external.lighthouse(url, lighthouseFlags, lightHouseConfig);
   } catch (err) {
-    console.error('Failed to launch Lighthouse', { url, lighthouseFlags, lightHouseConfig }, err);
+    logger.error(`Failed to launch Lighthouse.\nError: ${err}\nDebug: ${{ url, lighthouseFlags, lightHouseConfig }}`);
   }
 
   try {
     await chrome.kill();
   } catch (err) {
-    return console.error('Failed to quit Chrome', err);
+    return logger.error(`Failed to quit Chrome.\nError: ${err}`);
   }
 
   return results;
@@ -175,7 +174,7 @@ async function signInToBBCID(chrome, url) {
     .then(async (chromeProtocols) => {
       await loadSignInPage(url, chromeProtocols);
       await completeSignInProcess(chromeProtocols);
-    }).catch((err) => console.error('Could not obtain chrome protocols', err));
+    }).catch((err) => logger.error(`Could not obtain chrome protocols.\nError: ${err}`));
 }
 
 async function loadSignInPage(url, { Page }) {
@@ -185,9 +184,9 @@ async function loadSignInPage(url, { Page }) {
   return new Promise(async (resolve) => {
     await Page.enable();
     await Page.navigate({ url: signInUrl });
-    console.log('load sign in page - page navigated to');
+    logger.log('load sign in page - page navigated to');
     await Page.loadEventFired(() => {
-      console.log('load sign in page - load event fired');
+      logger.log('load sign in page - load event fired');
       return resolve();
     });
   });
@@ -195,7 +194,7 @@ async function loadSignInPage(url, { Page }) {
 
 function completeSignInProcess({ Page, Runtime }) {
   return new Promise(async (resolve) => {
-    console.log('sign in process - about to try to sign in');
+    logger.log('sign in process - about to try to sign in');
     const { username, password } = getSignInCredentials();
     const loginScript = `
       document.getElementById('user-identifier-input').value = '${username}';
@@ -203,9 +202,9 @@ function completeSignInProcess({ Page, Runtime }) {
       document.getElementById('submit-button').click();
     `;
     Runtime.evaluate({ expression: loginScript });
-    console.log('sign in process - login script invoked');
+    logger.log('sign in process - login script invoked');
     await Page.loadEventFired(() => {
-      console.log('sign in process - load event fired');
+      logger.log('sign in process - load event fired');
       return resolve();
     });
   });

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -193,17 +193,18 @@ async function loadSignInPage(url, { Page }) {
 
 function completeSignInProcess({ Page, Runtime }) {
   return new Promise(async (resolve) => {
+    console.log('sign in process - about to try to sign in');
     const { username, password } = getSignInCredentials();
     const loginScript = `
       document.getElementById('user-identifier-input').value = '${username}';
       document.getElementById('password-input').value = '${password}';
       document.getElementById('submit-button').click();
     `;
+    Runtime.evaluate({ expression: loginScript });
+    console.log('sign in process - login script invoked');
     await Page.loadEventFired(() => {
       console.log('sign in process - load event fired');
-      Runtime.evaluate({ expression: loginScript });
-      console.log('sign in process - login script invoked');
-      resolve();
+      return resolve();
     });
   });
 }

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -70,46 +70,45 @@ function run() {
     });
 }
 
-function runTestsForUrl({ url, shouldSignIn, hide, isPretty }) {
+async function runTestsForUrl({ url, shouldSignIn, hide, isPretty }) {
   logger.log(`Running audit for ${url}`);
-  return launchChromeAndRunLighthouse(url, shouldSignIn)
-    .then((results) => {
-      const suiteName = url.replace(/.*?:\/\//g, '').replace('\/', './');
-      const suite = reportBuilder.testSuite();
-      suite.name(suiteName);
+  try {
+    const results = await launchChromeAndRunLighthouse(url, shouldSignIn);
+    const suiteName = url.replace(/.*?:\/\//g, '').replace('\/', './');
+    const suite = reportBuilder.testSuite();
+    suite.name(suiteName);
 
-      const { audits, timing: { total: suiteDuration } } = results;
+    const { audits, timing: { total: suiteDuration } } = results;
 
-      suite.time(suiteDuration);
+    suite.time(suiteDuration);
 
-      const auditKeys = Object.keys(audits).filter((auditKey) => !audits[auditKey].manual);
-      const testCaseTime = (suiteDuration / auditKeys.length);
+    const auditKeys = Object.keys(audits).filter((auditKey) => !audits[auditKey].manual);
+    const testCaseTime = (suiteDuration / auditKeys.length);
 
-      auditKeys.forEach((auditKey) => {
-        const { score, manual, description, helpText, details = {}, extendedInfo = {} } = audits[auditKey];
-        const testCase = suite.testCase();
+    auditKeys.forEach((auditKey) => {
+      const { score, manual, description, helpText, details = {}, extendedInfo = {} } = audits[auditKey];
+      const testCase = suite.testCase();
 
-        testCase.className(suiteName);
-        testCase.name(description);
-        if (!isPretty) {
-          testCase.time(testCaseTime);
+      testCase.className(suiteName);
+      testCase.name(description);
+      if (!isPretty) {
+        testCase.time(testCaseTime);
+      }
+
+      if (score !== true && !manual) {
+        const errorMessage = `Error on ${url}\n${helpText}\n\n`;
+        const erroredElements = getErroredElements({ details, extendedInfo, hide });
+
+        if (erroredElements.length > 0) {
+          const errorDetail = getErrorDetail(erroredElements);
+          testCase.failure(errorMessage + errorDetail);
         }
-
-        if (score !== true && !manual) {
-          const errorMessage = `Error on ${url}\n${helpText}\n\n`;
-          const erroredElements = getErroredElements({ details, extendedInfo, hide });
-
-          if (erroredElements.length > 0) {
-            const errorDetail = getErrorDetail(erroredElements);
-            testCase.failure(errorMessage + errorDetail);
-          }
-        }
-      });
-    })
-    .catch((err) => {
-      logger.error(`An error occureding while launching Chrome and running Lighthouse.\nError: ${err}`);
-      process.exit(1);
+      }
     });
+  } catch (err) {
+    logger.error(`An error occureding while launching Chrome and running Lighthouse.\nError: ${err}`);
+    process.exit(1);
+  }
 }
 
 async function launchChromeAndRunLighthouse(url, shouldSignIn) {
@@ -117,7 +116,6 @@ async function launchChromeAndRunLighthouse(url, shouldSignIn) {
   const chromeOpts = getChromeOpts();
 
   let chrome;
-  let results;
 
   try {
     chrome = await chromeLauncher.launch(chromeOpts);
@@ -132,24 +130,23 @@ async function launchChromeAndRunLighthouse(url, shouldSignIn) {
   }
 
   try {
-    lighthouseFlags.port = chrome.port;
-    results = await external.lighthouse(url, lighthouseFlags, lightHouseConfig);
+    const flags = {
+      ...lighthouseFlags,
+      port: chrome.port
+    };
+    const results = await external.lighthouse(url, flags, lightHouseConfig);
+    return results;
   } catch (err) {
     logger.error(`Failed to launch Lighthouse.\nError: ${err}\nDebug: ${{ url, lighthouseFlags, lightHouseConfig }}`);
-  }
-
-  try {
+  } finally {
     await chrome.kill();
-  } catch (err) {
-    return logger.error(`Failed to quit Chrome.\nError: ${err}`);
   }
-
-  return results;
 }
 
 function getChromeOpts() {
   const defaultOpts = {
     chromeFlags: ['--disable-gpu', '--no-sandbox'],
+    connectionPollInterval: 500,
     maxConnectionRetries: 100,
     logLevel: 'error'
   };

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -198,7 +198,6 @@ async function loadSignInPage(url, { Page }) {
   return new Promise(async (resolve) => {
     await Page.enable();
     await Page.navigate({ url: signInUrl });
-    logger.log('load sign in page - page navigated to');
     await Page.loadEventFired(resolve);
   });
 }

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -107,7 +107,7 @@ function runTestsForUrl({ url, shouldSignIn, hide, isPretty }) {
       });
     })
     .catch((err) => {
-      logger.error(`An error occurding while launching Chrome and running Lighthouse.\nError: ${err}`);
+      logger.error(`An error occureding while launching Chrome and running Lighthouse.\nError: ${err}`);
       process.exit(1);
     });
 }
@@ -148,17 +148,20 @@ async function launchChromeAndRunLighthouse(url, shouldSignIn) {
 }
 
 function getChromeOpts() {
-  const defaultChromeFlags = ['--disable-gpu', '--no-sandbox'];
+  const defaultOpts = {
+    chromeFlags: ['--disable-gpu', '--no-sandbox'],
+    maxConnectionRetries: 100,
+    logLevel: 'error'
+  };
 
   if (process.env.A11Y_HEADLESS) {
     return {
-      chromeFlags: ['--headless', ...defaultChromeFlags]
+      ...defaultOpts,
+      chromeFlags: ['--headless', ...defaultOpts.chromeFlags]
     };
   }
 
-  return {
-    chromeFlags: defaultChromeFlags
-  };
+  return defaultOpts;
 }
 
 function completeSetupSteps(chrome, url, shouldSignIn) {
@@ -195,40 +198,24 @@ async function loadSignInPage(url, { Page }) {
   const encodedUrl = encodeURIComponent(url);
   const signInUrl = `https://account.bbc.com/signin?ptrt=${encodedUrl}`;
 
-  return new Promise(async (resolve, reject) => {
-    try {
-      await Page.enable();
-      await Page.navigate({ url: signInUrl });
-      logger.log('load sign in page - page navigated to');
-      await Page.loadEventFired(() => {
-        logger.log('load sign in page - load event fired');
-        return resolve();
-      });
-    } catch (err) {
-      return reject(err);
-    }
+  return new Promise(async (resolve) => {
+    await Page.enable();
+    await Page.navigate({ url: signInUrl });
+    logger.log('load sign in page - page navigated to');
+    await Page.loadEventFired(resolve);
   });
 }
 
 function completeSignInProcess({ Page, Runtime }) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      logger.log('sign in process - about to try to sign in');
-      const { username, password } = getSignInCredentials();
-      const loginScript = `
-        document.getElementById('user-identifier-input').value = '${username}';
-        document.getElementById('password-input').value = '${password}';
-        document.getElementById('submit-button').click();
-      `;
-      Runtime.evaluate({ expression: loginScript });
-      logger.log('sign in process - login script invoked');
-      await Page.loadEventFired(() => {
-        logger.log('sign in process - load event fired');
-        return resolve();
-      });
-    } catch (err) {
-      return reject(err);
-    }
+  return new Promise(async (resolve) => {
+    const { username, password } = getSignInCredentials();
+    const loginScript = `
+      document.getElementById('user-identifier-input').value = '${username}';
+      document.getElementById('password-input').value = '${password}';
+      document.getElementById('submit-button').click();
+    `;
+    Runtime.evaluate({ expression: loginScript });
+    await Page.loadEventFired(resolve);
   });
 }
 

--- a/test/lib/lighthouse.js
+++ b/test/lib/lighthouse.js
@@ -166,7 +166,12 @@ describe('lighthouse', () => {
 
       it('launches chrome once per path with the right options if A11Y_HEADLESS not set', () => {
         return lighthouseRunner.run().then(() => {
-          sandbox.assert.calledWith(chromeLauncher.launch, { chromeFlags: ['--disable-gpu', '--no-sandbox'] });
+          sandbox.assert.calledWith(chromeLauncher.launch, {
+            chromeFlags: ['--disable-gpu', '--no-sandbox'],
+            connectionPollInterval: 500,
+            maxConnectionRetries: 100,
+            logLevel: 'error'
+          });
           sandbox.assert.calledTwice(chromeLauncher.launch);
         });
       });
@@ -175,7 +180,12 @@ describe('lighthouse', () => {
         process.env.A11Y_HEADLESS = 'true';
 
         return lighthouseRunner.run().then(() => {
-          sandbox.assert.calledWith(chromeLauncher.launch, { chromeFlags: ['--headless', '--disable-gpu', '--no-sandbox'] });
+          sandbox.assert.calledWith(chromeLauncher.launch, {
+            chromeFlags: ['--headless', '--disable-gpu', '--no-sandbox'],
+            connectionPollInterval: 500,
+            maxConnectionRetries: 100,
+            logLevel: 'error'
+          });
           sandbox.assert.calledTwice(chromeLauncher.launch);
         });
       });


### PR DESCRIPTION
## Changes
- Increase the number of `maxConnectionRetries` that chrome launcher uses to check if chrome is up and running
- Convert promises to async await
- Increase logging
- Reorder sign in steps to wait for navigation to new page after sign in