### PR TITLE
IPLAYER-39705 - Add form submit button skip check on iPlayer web bundles and lists apps

### DIFF
--- a/config/iplayer-web/app-homepage-test-signed-in.js
+++ b/config/iplayer-web/app-homepage-test-signed-in.js
@@ -4,7 +4,7 @@ const { options: commonOptions, baseUrl } = require('./common');
 
 const commonSkips = commonOptions.skip;
 
-// Temporary fix for the dropdown component on the category pages
+// Temporarily skip test for the dropdown component on the category pages
 const listSpecificSkips = ['Forms: Managing focus: Forms must have submit buttons'];
 
 const options = Object.assign({}, commonOptions,

--- a/config/iplayer-web/app-homepage-test-signed-in.js
+++ b/config/iplayer-web/app-homepage-test-signed-in.js
@@ -4,6 +4,7 @@ const { options: commonOptions, baseUrl } = require('./common');
 
 const commonSkips = commonOptions.skip;
 
+// Temporary fix for the dropdown component on the category pages
 const listSpecificSkips = ['Forms: Managing focus: Forms must have submit buttons'];
 
 const options = Object.assign({}, commonOptions,

--- a/config/iplayer-web/app-homepage-test-signed-in.js
+++ b/config/iplayer-web/app-homepage-test-signed-in.js
@@ -1,6 +1,16 @@
 'use strict';
 
-const { options, baseUrl } = require('./common');
+const { options: commonOptions, baseUrl } = require('./common');
+
+const commonSkips = commonOptions.skip;
+
+const listSpecificSkips = ['Forms: Managing focus: Forms must have submit buttons'];
+
+const options = Object.assign({}, commonOptions,
+  {
+    skip: [...commonSkips, ...listSpecificSkips]
+  }
+);
 
 module.exports = {
   options,

--- a/config/iplayer-web/app-lists-test.js
+++ b/config/iplayer-web/app-lists-test.js
@@ -4,7 +4,7 @@ const { options: commonOptions, baseUrl } = require('./common');
 
 const commonSkips = commonOptions.skip;
 
-// Temporary fix for the dropdown component on the category pages
+// Temporarily skip test for the dropdown component on the category pages
 const listSpecificSkips = ['Forms: Managing focus: Forms must have submit buttons'];
 
 const options = Object.assign({}, commonOptions,

--- a/config/iplayer-web/app-lists-test.js
+++ b/config/iplayer-web/app-lists-test.js
@@ -4,6 +4,7 @@ const { options: commonOptions, baseUrl } = require('./common');
 
 const commonSkips = commonOptions.skip;
 
+// Temporary fix for the dropdown component on the category pages
 const listSpecificSkips = ['Forms: Managing focus: Forms must have submit buttons'];
 
 const options = Object.assign({}, commonOptions,

--- a/config/iplayer-web/app-lists-test.js
+++ b/config/iplayer-web/app-lists-test.js
@@ -1,6 +1,16 @@
 'use strict';
 
-const { options, baseUrl } = require('./common');
+const { options: commonOptions, baseUrl } = require('./common');
+
+const commonSkips = commonOptions.skip;
+
+const listSpecificSkips = ['Forms: Managing focus: Forms must have submit buttons'];
+
+const options = Object.assign({}, commonOptions,
+  {
+    skip: [...commonSkips, ...listSpecificSkips]
+  }
+);
 
 module.exports = {
   options,


### PR DESCRIPTION
https://jira.dev.bbc.co.uk/browse/IPLAYER-39705
# Changes

Fixes A11Y tests in Jenkins pipeline for the bundles and lists web apps:

```
<failure message="Error on https://www.test.bbc.co.uk/bbcone/a-z&#xA;Form has no submit button: //div[@id='main']/footer/div/div[1]/form[1]&#xA;Form has no submit button: //div[@id='main']/footer/div/div[1]/form[2]&#xA;More info at http://www.bbc.co.uk/guidelines/futuremedia/accessibility/mobile/forms/managing-focus"/>
```

In Google Chrome, the dropdown switcher on the category pages displays the incorrect value when using the browser's back button. This is solved by having the dropdown component inside of a `<form />` element. 

However, we’re running into some issues with the a11y tests in our pipeline - running bbc-a11y where it fails on this spec file, stating  Forms must have submit buttons . In our use case, a `<button type="submit" />` element would not work as selecting a category from the dropdown redirects the user to their chosen category page.

