### PR TITLE
Add default verify:release to the package.json (PLAYBACK-348, BROWSE-451)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint": "npm run clean && eslint .",
     "test": "mocha 'test/**/*.js' && npm run lint",
     "coverage": "nyc --reporter=lcov npm test && nyc report",
-    "publish:safe": "npx @bbc/iplayer-web-safe-publish"
+    "publish:safe": "npx @bbc/iplayer-web-safe-publish",
+    "verify:release": "npm run test && npm run build"
   },
   "author": "Andy Smith",
   "license": "Apache-2.0",


### PR DESCRIPTION

**Summary of changes:**

- Updated the package.json to ensure verify release is present to ensure the publish:safe script works as it is dependent on the verify:release script

**Tickets:**
- [PLAYBACK-348](https://bbc.atlassian.net/browse/PLAYBACK-348)
- [BROWSE-451](https://bbc.atlassian.net/browse/BROWSE-451)
